### PR TITLE
Support host ports without portsecurity.

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 2.2.2
+version: 2.2.3.dev1498758188
 compiler_version: 2017.1


### PR DESCRIPTION
Allow the use of HostPort when portsecurity is not enabled. 

The model refactor for the 2.0 version always creates a hostport for a virtual machine. Before that the port management code was also replicated in the virtual machine handler. This lead to this regression.