### PR TITLE
test if project_id is not None when looking for subnets

### DIFF
--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -629,7 +629,10 @@ class OpenStackHandler(CRUDHandler):
         if name is not None:
             subnets = self._neutron.list_subnets(tenant_id=project_id, name=name)
         elif subnet_id is not None:
-            subnets = self._neutron.list_subnets(tenant_id=project_id, id=subnet_id)
+            if project_id is not None:
+                subnets = self._neutron.list_subnets(tenant_id=project_id, id=subnet_id)
+            else:
+                subnets = self._neutron.list_subnets(id=subnet_id)
         else:
             raise Exception("Either a name or an id needs to be provided.")
 


### PR DESCRIPTION
Test if `project_id` is not `None` in order to not filter the subnet results when it is not necessary.
It addresses a warning that was raised (and explained in Issue #11) because no subnet was found. It fixes that issue.