### PR TITLE
Fix scoping issue on the SecurityGroup resource

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#3.6.1
+- Fix scoping issue on SecurityGroup resource
+
 #3.6.0
 - Add support to disable SSL verification (#152)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,5 @@
 #3.6.1
-- Fix scoping issue on SecurityGroup resource
+- Fix scoping issue on SecurityGroup resource (#184)
 
 #3.6.0
 - Add support to disable SSL verification (#152)

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 3.6.0
+version: 3.6.1.dev1603366988
 compiler_version: 2020.2

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1074,9 +1074,7 @@ class OpenStackHandler(CRUDHandler):
         """
         Get security group details from openstack
         """
-        if (name is None and group_id is None) or (
-            name is not None and group_id is not None
-        ):
+        if (name is None) == (group_id is None):
             raise Exception(
                 "Argument 'name' or 'group_id' should be provided, but never both"
             )


### PR DESCRIPTION
# Description

The `get_security_group()` method used to return security groups which were present outside of the scope of the given project. This patch fixes that issue.

closes #184 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
