### PR TITLE
Pin PyOpenssl for compatibility with openssl 1.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#3.6.10
+- Pin PyOpenssl for compatibility with openssl 1.0.2
+
 #3.6.9
 - Remove transitive dependencies
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 3.6.9
+version: 3.6.10.dev1606982598
 compiler_version: 2020.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,6 @@ python-keystoneclient~=4.1
 python-novaclient~=17.2
 python-neutronclient~=7.2
 python-glanceclient<3.3
+
+pyOpenSSL~=19.1.0
+cryptography~=3.1.0


### PR DESCRIPTION
# Description

Pinning these versions is necessary for openssl 1.0.2 compatibility and was removed by accident (related to inmanta/infra-tickets#93)

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] ~Attached issue to pull request~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [ ] ~Code is clear and sufficiently documented~
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
