### PR TITLE
Add setuptools rust dependency

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#3.6.11
+- Add setuptools-rust dependency required to build the cryptography package.
+
 #3.6.10
 - Pin PyOpenssl for compatibility with openssl 1.0.2
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 3.6.10
+version: 3.6.11.dev1613480132
 compiler_version: 2020.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-glanceclient<3.3
 
 pyOpenSSL~=19.1.0
 cryptography~=3.1.0
+setuptools-rust~=0.11.6


### PR DESCRIPTION
# Description

Add `setuptools-rust` dependency required to build the cryptography dependency.