### PR TITLE
Fix wait condition on delete of openstack::VirtualMachine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.7.2
+- Fix wait condition on delete of openstack::VirtualMachine
+
 # 3.7.1
 - Ensure correct detection of deleted HostPorts (#286)
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 3.7.1
+version: 3.7.2.dev1625487741
 compiler_version: 2020.2

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1509,10 +1509,16 @@ class VirtualMachineHandler(OpenStackHandler):
         server = ctx.get("server")
         server.delete()
 
+        def is_server_deletion_finished() -> bool:
+            ports = self._neutron.list_ports(device_id=server.id)
+            if len(ports["ports"]) > 0:
+                return False
+            return self.get_vm(ctx, resource) is None
+
         # Wait until the server has been deleted
         count = 0
         ctx.info("Waiting until server is deleted.")
-        while self.get_vm(ctx, resource) is not None and count < 60:
+        while not is_server_deletion_finished() and count < 60:
             time.sleep(1)
             count += 1
 

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1511,16 +1511,12 @@ class VirtualMachineHandler(OpenStackHandler):
 
         # Wait until the server has been deleted
         count = 0
-        ctx.info("Server deleted, waiting for neutron to report all ports deleted.")
-        while server is not None and count < 60:
-            ports = self._neutron.list_ports(device_id=server.id)
-            if len(ports["ports"]) > 0:
-                time.sleep(1)
-                count += 1
-            else:
-                server = None
+        ctx.info("Waiting until server is deleted.")
+        while self.get_vm(ctx, resource) is not None and count < 60:
+            time.sleep(1)
+            count += 1
 
-        if server is not None:
+        if count >= 60:
             ctx.warning("Delete still in progress, giving up waiting.")
 
         ctx.set_purged()


### PR DESCRIPTION
# Description

Make sure that the `delete_resource` handler of `openstack::VirtualMachine` waits until the VM is deleted.

# Self Check:

- [ ] ~~Attached issue to pull request~~
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

# Reviewer Checklist:

- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Code is clear and sufficiently documented
- [ ] Correct, in line with design
