### PR TITLE
Add timeout to image create handler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+# 3.7.5
+- Fix the bug that makes the `openstack::Image` handler hang when the newly created image doesn't enter the `active` status.
+
 # 3.7.3
 - openstack::FloatingIP resource set its ip_address fact on creation
 

--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 3.7.4
+version: 3.7.5.dev1644830957
 compiler_version: 2020.2

--- a/plugins/__init__.py
+++ b/plugins/__init__.py
@@ -1316,14 +1316,15 @@ class ImageHandler(OpenStackHandler):
         if timeout < 0:
             raise Exception(f"Timeout cannot be negative: {timeout}")
         start_time = time.time()
-        image = self._get_image_by_id(image_id)
-        while (
-            not image or image.status != "active"
-        ) and time.time() < start_time + timeout:
-            time.sleep(0.1)
+        image = None
+        while time.time() < start_time + timeout:
             image = self._get_image_by_id(image_id)
+            if image and image.status == "active":
+                return
+            time.sleep(0.1)
         raise Exception(
-            f"A timeout occurred while waiting for image {image_id} to enter the `active` state (status={image.status})"
+            f"A timeout occurred while waiting for image {image_id} to enter the `active` state "
+            f"(status={image.status if image else None})"
         )
 
     def delete_resource(

--- a/setup.cfg
+++ b/setup.cfg
@@ -21,6 +21,7 @@ max-line-length = 128
 exclude = **/.env,venv
 copyright-check=True
 copyright-author=Inmanta
+select = E,F,W,C,BLK,I
 
 [isort]
 multi_line_output=3

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/test_dependency_handling.py
+++ b/tests/test_dependency_handling.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 from inmanta.resources import Id
 
 all_model = """

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import os
 import re
 

--- a/tests/test_flavor.py
+++ b/tests/test_flavor.py
@@ -1,3 +1,20 @@
+"""
+    Copyright 2022 Inmanta
+
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import os
 
 import inmanta

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -86,7 +86,9 @@ image=openstack::Image(
     assert ctx_deploy_1.status == inmanta.const.ResourceState.skipped
 
     handler = project.get_handler(created_image, run_as_root=False)
-    handler._wait_for_image_to_become_active(image_id=created_image.id)
+    handler.pre(ctx=None, resource=created_image)
+    image_id = get_test_image(glance)[0].id
+    handler._wait_for_image_to_become_active(image_id)
 
     ctx_deploy_2 = project.deploy(created_image)
     assert ctx_deploy_2.status == inmanta.const.ResourceState.deployed

--- a/tests/test_image.py
+++ b/tests/test_image.py
@@ -1,5 +1,20 @@
-import time
+"""
+    Copyright 2022 Inmanta
 
+    Licensed under the Apache License, Version 2.0 (the "License");
+    you may not use this file except in compliance with the License.
+    You may obtain a copy of the License at
+
+        http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+
+    Contact: code@inmanta.com
+"""
 import inmanta
 import pytest
 
@@ -70,11 +85,8 @@ image=openstack::Image(
     ctx_deploy_1 = project.deploy(created_image)
     assert ctx_deploy_1.status == inmanta.const.ResourceState.skipped
 
-    while True:
-        test_image = get_test_image(glance)[0]
-        if test_image.status == "active":
-            break
-        time.sleep(0.1)
+    handler = project.get_handler(created_image, run_as_root=False)
+    handler._wait_for_image_to_become_active(image_id=created_image.id)
 
     ctx_deploy_2 = project.deploy(created_image)
     assert ctx_deploy_2.status == inmanta.const.ResourceState.deployed

--- a/tests/test_keystone.py
+++ b/tests/test_keystone.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/test_neutron.py
+++ b/tests/test_neutron.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.

--- a/tests/test_nova.py
+++ b/tests/test_nova.py
@@ -1,5 +1,5 @@
 """
-    Copyright 2017 Inmanta
+    Copyright 2022 Inmanta
 
     Licensed under the Apache License, Version 2.0 (the "License");
     you may not use this file except in compliance with the License.


### PR DESCRIPTION
# Description

Fix the bug that makes the `openstack::Image` handler hang when the newly created image doesn't enter the `active` status.

closes #182 

# Self Check:

- [x] Attached issue to pull request
- [x] Changelog entry
- [x] Version number is bumped to dev version
- [x] Code is clear and sufficiently documented
- [x] Sufficient test cases (reproduces the bug/tests the requested feature)
- [x] Correct, in line with design
- [ ] ~~End user documentation is included or an issue is created for end-user documentation~~

