### PR TITLE
fix version setuptool-rust

### DIFF
--- a/module.yml
+++ b/module.yml
@@ -1,5 +1,5 @@
 author: Inmanta <code@inmanta.com>
 license: Apache 2.0
 name: openstack
-version: 3.7.8
+version: 3.7.9.dev1649320516
 compiler_version: 2020.2

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,2 +1,4 @@
 inmanta-dev-dependencies[module]==1.76.0; python_version <= '3.6'
 inmanta-dev-dependencies[module]==2.12.0; python_version > '3.6'
+setuptool-rust~=1.1.2; python_version <= '3.6'
+setuptool-rust~=1.2.0; python_version > '3.6'

--- a/requirements.dev.txt
+++ b/requirements.dev.txt
@@ -1,4 +1,2 @@
 inmanta-dev-dependencies[module]==1.76.0; python_version <= '3.6'
 inmanta-dev-dependencies[module]==2.12.0; python_version > '3.6'
-setuptool-rust~=1.1.2; python_version <= '3.6'
-setuptool-rust~=1.2.0; python_version > '3.6'

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,5 @@ python-glanceclient<3.7
 
 pyOpenSSL~=22.0.0
 cryptography~=36.0.2
-setuptools-rust~=1.2.0
+setuptools-rust~=1.1.2; python_version <= '3.6'
+setuptools-rust~=1.2.0; python_version > '3.6'


### PR DESCRIPTION
# Description

setuptool-rust dropped support for python3.6. This commit adds a condition on the python version to
use the right setuptool-rust version accordingly. 

# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

