### PR TITLE
Revert "Update cryptography requirement from ~=37.0.2 to ~=37.0.3"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ python-neutronclient~=7.8
 python-glanceclient<4.1
 
 pyOpenSSL~=22.0.0
-cryptography~=37.0.3
+cryptography~=37.0.2
 setuptools-rust~=1.1.2; python_version <= '3.6'
 setuptools-rust~=1.3.0; python_version > '3.6'


### PR DESCRIPTION
Reverts inmanta/openstack#388

37.0.3 was yanked as described here: https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst