### PR TITLE
[FIX] revert dependency bump because it got yanked

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,6 @@ python-neutronclient~=8.1
 python-glanceclient<4.2
 
 pyOpenSSL~=22.1.0
-cryptography~=38.0.2
+cryptography~=38.0.1
 setuptools-rust~=1.1.2; python_version <= '3.6'
 setuptools-rust~=1.5.2; python_version > '3.6'


### PR DESCRIPTION
# Description

Cryptography [38.0.2](https://github.com/pyca/cryptography/blob/main/CHANGELOG.rst#3802---2022-10-11-yanked) got yanked --> reverting to 38.0.1



# Merge procedure

Don't use the github built-in merge, but the process described [here](https://docs.internal.inmanta.com/topics/tasks/commiting_changes_modules.html)

```sh
git pull
git checkout master
git pull
git merge --squash issue/{issue-number}-{short description}
inmanta module commit -m "{Commit Message Here}" -r
git push
git push {tag} # push the tag as well
```

Then close the PR with a reference to the commit

# Self Check:

Strike through any lines that are not applicable (`~~line~~`) then check the box

- [ ] Attached issue to pull request
- [ ] Changelog entry
- [ ] Version number is bumped to dev version
- [ ] Code is clear and sufficiently documented
- [ ] Sufficient test cases (reproduces the bug/tests the requested feature)
- [ ] Correct, in line with design
- [ ] End user documentation is included or an issue is created for end-user documentation (add ref to issue here: )

